### PR TITLE
Add PDF export to residual report

### DIFF
--- a/app/components/FinalPreview.tsx
+++ b/app/components/FinalPreview.tsx
@@ -63,7 +63,7 @@ export default function FinalPreview() {
                 </div>
                 {exp.responsibilities.filter((resp) => resp.trim() !== "")
                   .length > 0 && (
-                  <ul className="list-disc ml-4 text-sm">
+                  <ul className="list-disc list-inside ml-2 text-sm leading-tight">
                     {exp.responsibilities
                       .filter((resp) => resp.trim() !== "")
                       .map((resp, i) => (
@@ -83,7 +83,7 @@ export default function FinalPreview() {
             Skills
           </h2>
           {skills.length > 0 && skills[0] !== "" && (
-            <ul className="list-disc ml-4 text-sm">
+            <ul className="list-disc list-inside ml-2 text-sm leading-tight">
               {skills.map((skill, i) => (
                 <li key={i} className="mb-0.5">
                   {skill}

--- a/app/components/FinalPreview.tsx
+++ b/app/components/FinalPreview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useWizard } from "../context/WizardContext";
+import "../../styles/pdf.css";
 
 export default function FinalPreview() {
   const { identity, content } = useWizard();
@@ -11,7 +12,7 @@ export default function FinalPreview() {
     <div className="min-h-screen w-full flex items-center justify-center bg-gray-100 p-8">
       <div
         id="resume-preview-content"
-        className="bg-white mx-auto shadow-lg border border-gray-200"
+        className="pdf-resume bg-white mx-auto shadow-lg border border-gray-200"
         style={{
           width: "8.5in",
           padding: "0.75in",

--- a/app/components/FinalPreview.tsx
+++ b/app/components/FinalPreview.tsx
@@ -63,7 +63,7 @@ export default function FinalPreview() {
                 </div>
                 {exp.responsibilities.filter((resp) => resp.trim() !== "")
                   .length > 0 && (
-                  <ul className="list-disc list-inside ml-2 text-sm leading-tight">
+                  <ul className="list-disc ml-4 text-sm">
                     {exp.responsibilities
                       .filter((resp) => resp.trim() !== "")
                       .map((resp, i) => (
@@ -83,7 +83,7 @@ export default function FinalPreview() {
             Skills
           </h2>
           {skills.length > 0 && skills[0] !== "" && (
-            <ul className="list-disc list-inside ml-2 text-sm leading-tight">
+            <ul className="list-disc ml-4 text-sm">
               {skills.map((skill, i) => (
                 <li key={i} className="mb-0.5">
                   {skill}

--- a/app/wizard/industry/page.tsx
+++ b/app/wizard/industry/page.tsx
@@ -70,10 +70,10 @@ export default function IndustryStep() {
       </div>
 
       {industry && (
-        <div className="fixed bottom-0 left-0 w-full bg-white dark:bg-gray-900 border-t p-4">
+        <div className="fixed bottom-0 left-0 w-full bg-white dark:bg-gray-900 border-t p-4 flex justify-center">
           <button
             onClick={() => router.push("/wizard/profile")}
-            className="w-full px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium transition-colors"
+            className="w-full max-w-md px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium transition-colors"
           >
             Continue →
           </button>

--- a/app/wizard/report/page.tsx
+++ b/app/wizard/report/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useWizard } from "../../context/WizardContext";
 import ResidualSelfhoodReport from "../../components/ResidualSelfhoodReport";
 import FinalPreview from "../../components/FinalPreview";
+import { HiOutlineDownload, HiOutlineRefresh } from "react-icons/hi";
 
 export default function ReportPage() {
   const router = useRouter();
@@ -46,14 +47,16 @@ export default function ReportPage() {
       <div className="fixed bottom-0 left-0 w-full bg-white dark:bg-gray-900 border-t p-4 flex gap-4 justify-center items-center">
         <button
           onClick={handleExportPdf}
-          className="px-6 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 font-medium text-lg shadow-lg transform transition hover:scale-105"
+          className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium text-lg shadow-lg flex items-center gap-2"
         >
+          <HiOutlineDownload className="h-5 w-5" />
           Export Resume PDF
         </button>
         <button
           onClick={handleStartOver}
-          className="px-6 py-3 bg-gray-800 text-white rounded-lg hover:bg-gray-700 font-medium text-lg shadow-lg transform transition hover:scale-105"
+          className="px-6 py-3 bg-gray-100 text-gray-800 rounded-lg hover:bg-gray-200 font-medium text-lg shadow flex items-center gap-2"
         >
+          <HiOutlineRefresh className="h-5 w-5" />
           Start Over
         </button>
       </div>

--- a/app/wizard/report/page.tsx
+++ b/app/wizard/report/page.tsx
@@ -3,10 +3,26 @@
 import { useRouter } from "next/navigation";
 import { useWizard } from "../../context/WizardContext";
 import ResidualSelfhoodReport from "../../components/ResidualSelfhoodReport";
+import FinalPreview from "../../components/FinalPreview";
 
 export default function ReportPage() {
   const router = useRouter();
   const { distortionIndex, resetWizard } = useWizard();
+
+  const handleExportPdf = async () => {
+    const element = document.getElementById("resume-preview-content");
+    if (!element) return;
+    const html2pdf = (await import("html2pdf.js")).default;
+    await html2pdf()
+      .set({
+        margin: 0,
+        filename: "survival_resume.pdf",
+        html2canvas: { scale: 2 },
+        jsPDF: { unit: "in", format: "letter", orientation: "portrait" },
+      })
+      .from(element)
+      .save();
+  };
 
   const handleStartOver = () => {
     resetWizard();
@@ -19,14 +35,24 @@ export default function ReportPage() {
       <div className="flex-1 overflow-y-auto pb-24">
         <div className="max-w-4xl mx-auto my-8 p-8">
           <ResidualSelfhoodReport distortionIndex={distortionIndex} />
+          {/* Hidden resume preview for PDF export */}
+          <div className="absolute -left-[9999px]">
+            <FinalPreview />
+          </div>
         </div>
       </div>
 
       {/* Fixed footer */}
-      <div className="fixed bottom-0 left-0 w-full bg-white dark:bg-gray-900 border-t p-4 flex justify-center items-center">
+      <div className="fixed bottom-0 left-0 w-full bg-white dark:bg-gray-900 border-t p-4 flex gap-4 justify-center items-center">
+        <button
+          onClick={handleExportPdf}
+          className="px-6 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 font-medium text-lg shadow-lg transform transition hover:scale-105"
+        >
+          Export Resume PDF
+        </button>
         <button
           onClick={handleStartOver}
-          className="px-8 py-3 bg-gray-800 text-white rounded-lg hover:bg-gray-700 font-medium text-lg shadow-lg transform transition hover:scale-105"
+          className="px-6 py-3 bg-gray-800 text-white rounded-lg hover:bg-gray-700 font-medium text-lg shadow-lg transform transition hover:scale-105"
         >
           Start Over
         </button>

--- a/app/wizard/review/page.tsx
+++ b/app/wizard/review/page.tsx
@@ -6,6 +6,7 @@ import WizardPageLayout from "../../components/WizardPageLayout";
 import MobileResumePreview from "../../components/MobileResumePreview";
 import { useEffect, useState } from "react";
 import { FEATURE_FLAGS } from "../../config/feature-flags";
+import { HiOutlineArrowNarrowRight } from "react-icons/hi";
 
 export default function ReviewStep() {
   const router = useRouter();
@@ -26,22 +27,25 @@ export default function ReviewStep() {
       </div>
 
       {/* Fixed footer */}
-      <div className="fixed bottom-0 left-0 w-full bg-white dark:bg-gray-900 border-t p-4 flex justify-between items-center">
-        <button
-          onClick={() => router.push("/wizard/skills")}
-          className="px-6 py-2 text-gray-600 hover:text-gray-800"
-        >
-          ← Back to Skills
-        </button>
-
-        {FEATURE_FLAGS.ENABLE_RESIDUAL_REPORT && (
+      <div className="fixed bottom-0 left-0 w-full bg-white dark:bg-gray-900 border-t p-4 flex justify-center">
+        <div className="w-full max-w-2xl flex justify-between items-center gap-4">
           <button
-            onClick={() => router.push("/wizard/report")}
-            className="px-8 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 font-medium text-lg shadow-lg transform transition hover:scale-105"
+            onClick={() => router.push("/wizard/skills")}
+            className="px-6 py-2 text-gray-600 hover:text-gray-800"
           >
-            Assess Residual Selfhood
+            ← Back to Skills
           </button>
-        )}
+
+          {FEATURE_FLAGS.ENABLE_RESIDUAL_REPORT && (
+            <button
+              onClick={() => router.push("/wizard/report")}
+              className="px-8 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 font-medium text-lg shadow-lg transform transition hover:scale-105 flex items-center gap-2"
+            >
+              Assess Residual Selfhood
+              <HiOutlineArrowNarrowRight className="h-5 w-5" />
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "puppeteer": "^24.7.2",
         "react": "^18",
         "react-dom": "^18",
+        "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "resize-observer-polyfill": "^1.5.1"
       },
@@ -36,6 +37,7 @@
         "eslint-config-next": "14.1.0",
         "jsdom": "^26.1.0",
         "postcss": "^8.4.35",
+        "prettier": "^3.3.3",
         "tailwindcss": "^3.4.1",
         "typescript": "^5",
         "vitest": "^1.6.1"
@@ -8673,6 +8675,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -8885,6 +8903,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "puppeteer": "^24.7.2",
     "react": "^18",
     "react-dom": "^18",
+    "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "resize-observer-polyfill": "^1.5.1"
   },

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -38,4 +38,22 @@ body {
     /* we'll override this from Puppeteer */
     transform: scale(1);
   }
+
+  /* Use custom bullets for reliable vertical alignment */
+  #resume-preview-content ul {
+    list-style: none;
+    padding-left: 1rem;
+  }
+
+  #resume-preview-content li {
+    display: flex;
+    align-items: flex-start;
+    margin-bottom: 0.25rem;
+  }
+
+  #resume-preview-content li::before {
+    content: "\2022"; /* bullet */
+    margin-right: 0.5rem;
+    line-height: 1;
+  }
 }

--- a/styles/pdf.css
+++ b/styles/pdf.css
@@ -1,7 +1,8 @@
 /* PDF-specific styles */
 .pdf-resume {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   color: #000;
   background-color: #fff;
@@ -97,7 +98,7 @@
 
 .pdf-resume li {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   margin-bottom: 4px;
   font-size: 14px;
   line-height: 1.4;
@@ -105,12 +106,19 @@
 
 .pdf-resume li::before {
   content: "•";
-  margin-right: 8px;
+  margin-right: 10px;
+  font-size: 1.3em;
+  color: #222;
+  line-height: 1;
+  position: relative;
+  top: -1px;
+  vertical-align: middle;
 }
 
 .markdown-content {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
-    Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   color: #333;
   max-width: 8.5in;


### PR DESCRIPTION
## Summary
- enable PDF export from the residual selfhood report page
- hide a final resume preview for the export

## Testing
- `npm test` *(fails: `vitest: not found`)*
- `npm install` *(fails: puppeteer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850ae5639cc83338349db21231f3d66